### PR TITLE
Add ability to wrap an existing MX symbolic object in opti variable.

### DIFF
--- a/src/OptimizationObject.m
+++ b/src/OptimizationObject.m
@@ -15,12 +15,24 @@ classdef OptimizationObject < casadi.MX
            n=1;
         end
         function self = OptimizationObject(shape,name)
-           if isscalar(shape)
-               shape = [shape 1];
-           end
-           self@casadi.MX(casadi.MX.sym(name,casadi.Sparsity.dense(shape(1),shape(2))));
-           mymapping = OptimizationObject.mapping;
-           mymapping(self.hash()) = self;
+            % Create an MX symbolic object either by shape & name, or by
+            % wrapping an existing MX object.
+            create_new_object = true;
+            if isa(shape, 'casadi.MX')
+                assert(shape.is_symbolic(), 'Only an MX symbolic object can be wrapped.');
+                the_object = shape;
+                create_new_object = false;
+            else
+                if isscalar(shape)
+                    shape = [shape 1];
+                end
+            end
+            if create_new_object
+                the_object = casadi.MX.sym(name,casadi.Sparsity.dense(shape(1),shape(2)));
+            end
+            self@casadi.MX(the_object);
+            mymapping = OptimizationObject.mapping;
+            mymapping(self.hash()) = self;
         end
         function val = optival(self)
             val = self.value;

--- a/src/optipar.m
+++ b/src/optipar.m
@@ -29,21 +29,27 @@ classdef optipar < OptimizationObject
             %  x = optipar(n)                  Column vector of length n
             %  x = optipar(n,m)                Matrix of shape n-by-m
             %  x = optipar(n,m,name)           A name for printing the variable
-           if isempty(varargin)
+            %  x = optipar(obj)                Wrap an existing MX object
+           if nargin == 0
                shape = 1;
-           elseif length(varargin)==1
+           elseif nargin == 1
                shape = varargin{1};
-           elseif length(varargin)>1
+           elseif nargin > 1
                shape = [varargin{1};varargin{2}];
            end
            
-           if length(varargin)==3
-               name = varargin{3};
+           if nargin == 3
+               name = varargin(3);
            else
-               name = 'p';
+               if isnumeric(shape)
+                   name = {'p'};  % automatic name
+               else
+                   name = {};   % wrapping an object
+               end
            end
            
-           self@OptimizationObject(shape,name);
+           % name is a cell, could be empty
+           self@OptimizationObject(shape,name{:});
         end
     end
     

--- a/src/optisolve.m
+++ b/src/optisolve.m
@@ -60,6 +60,9 @@ classdef optisolve < handle
             %                    codegen (true|false) compile-and-load code
             %                    ipopt (struct) pass options on to ipopt
             %
+            %     solver      - string
+            %                   the solver name, default: ipopt
+            %
             % The solution of the NLP may be obtained using optival:
             %
             %  x = optivar();
@@ -70,14 +73,19 @@ classdef optisolve < handle
             %
             %
             % See also OPTIVAR, OPTIPAR, OPTIVAL
-            if length(varargin)>=1
+            if length(varargin) >= 1
                 constraints = varargin{1};
             else
                 constraints = {};
             end
             options = struct;
-            if length(varargin)>=2
+            if length(varargin) >= 2
                 options = varargin{2};
+            end
+            solver = 'ipopt';
+            if length(varargin) >= 3
+                assert(ischar(varargin{3}), 'Solver name must be a string.');
+                solver = varargin{3};
             end
 
             import casadi.*
@@ -173,14 +181,15 @@ classdef optisolve < handle
             end
             
             %opt.starcoloring_threshold = 1000;
-            opt.monitor = char('eval_hess','eval_f','eval_grad_f','eval_jac_g');
+            %opt.monitor = char('eval_hess','eval_f','eval_grad_f','eval_jac_g');
             
-            nlp = Function('nlp',struct('x',X,'p',P,'f',total_objective,'g',gl_pure_v),char('x','p'),char('f','g'),opt);
-
-            if isfield(options,'expand') && options.expand
-               nlp = nlp.expand();
-               options = rmfield(options,'expand');
-            end
+            %nlp = Function('nlp',struct('x',X,'p',P,'f',total_objective,'g',gl_pure_v),char('x','p'),char('f','g'),opt);
+            nlp = struct('x',X,'p',P,'f',total_objective,'g',gl_pure_v);
+            
+%             if isfield(options,'expand') && options.expand
+%                 nlp = nlp.expand();
+%                 options = rmfield(options,'expand');
+%             end
 
             if codegen
                 disp('Computing derivatives')
@@ -250,7 +259,7 @@ classdef optisolve < handle
             end
 
 
-            self.solver = nlpsol('solver','ipopt', nlp, options);
+            self.solver = nlpsol('solver',solver, nlp, options);
 
             % Save to class properties
             self.symbols      = symbols;

--- a/src/optisolve.m
+++ b/src/optisolve.m
@@ -219,16 +219,16 @@ classdef optisolve < handle
                 jac_g.generate('nlp_jac_g');
                 hess_lag.generate('nlp_hess_l');
                 
-                jit_options = struct('flags',char('-O3',''));%,'plugin_libs',char('linearsolver_lapacklu',''));
-
+                jit_options = struct('compiler', 'clang', 'flags', char('-O3',''));%,'plugin_libs',char('linearsolver_lapacklu',''));
+                
                 disp('Compiling')
-                nlp_compiler = Compiler('nlp.c','clang',jit_options);
+                nlp_compiler = Compiler('nlp.c','shell',jit_options);
                 nlp = external('nlp',nlp_compiler,struct);
-                grad_f_compiler = Compiler('nlp_grad_f.c','clang',jit_options);
+                grad_f_compiler = Compiler('nlp_grad_f.c','shell',jit_options);
                 grad_f = external('nlp_grad_f',grad_f_compiler,struct);
-                jac_g_compiler = Compiler('nlp_jac_g.c','clang',jit_options);
+                jac_g_compiler = Compiler('nlp_jac_g.c','shell',jit_options);
                 jac_g = external('nlp_jac_g',jac_g_compiler,struct);
-                hess_lag_compiler = Compiler('nlp_hess_l.c','clang',jit_options);
+                hess_lag_compiler = Compiler('nlp_hess_l.c','shell',jit_options);
                 hess_lag = external('nlp_hess_l',hess_lag_compiler,struct);
                 
                 extra = struct;

--- a/src/optisolve.m
+++ b/src/optisolve.m
@@ -33,6 +33,22 @@ classdef optisolve < handle
             ng % Number of constraints
             np % Number of parameters
     end
+    
+    % Properties used for fmincon
+    properties(SetAccess=private)
+        m_objfunc   % The objective function, as a Function object
+        m_objfunc_g % The gradient of objective function, that returns both f and grad_f
+        m_ieqc      % Inequality constraints g <= 0
+        m_ieqc_j    % Jacobian of inequality constraints (and the constraints)
+        m_eqc       % Equality constraints g == 0, including jacobian
+        m_eqc_j     % Jacobian of equality constraints (and the constraints)
+        
+        m_p0        % The values of parameters in the current resolve()
+        
+        m_fmincon_opt   % Options for fmincon()
+        
+        m_fmincon = false;  % If fmincon is used
+    end
 
     methods
 
@@ -73,13 +89,16 @@ classdef optisolve < handle
             %
             %
             % See also OPTIVAR, OPTIPAR, OPTIVAL
+            
+            % optisolve_start = tic;
+            
             if length(varargin) >= 1
                 constraints = varargin{1};
             else
                 constraints = {};
             end
             options = struct;
-            if length(varargin) >= 2
+            if length(varargin) >= 2 && isstruct(varargin{2})
                 options = varargin{2};
             end
             solver = 'ipopt';
@@ -87,80 +106,64 @@ classdef optisolve < handle
                 assert(ischar(varargin{3}), 'Solver name must be a string.');
                 solver = varargin{3};
             end
-
+            self.m_fmincon = strcmpi(solver, 'fmincon');
+            
             import casadi.*
-
+            
             if ~iscell(constraints) || ~(isvector(constraints) || isempty(constraints))
                 error('Constraints must be given as cell array: {x>=0,y<=0}');
             end
             if length(constraints)~=size(constraints,2)
                 constraints = constraints';
             end
-
-
+            
+            
             [ gl_pure, gl_equality] = sort_constraints( constraints );
             [ scalar_objectives, twonorm_objectives, total_scalar_objective, total_objective ] = sort_objectives( objective );
-
-            symbols = OptimizationObject.get_primitives({total_objective gl_pure{:}});
-
+            
+            symbols = OptimizationObject.get_primitives([{total_objective} gl_pure]);
+            
             % helper functions for 'x'
             X = veccat(symbols.x{:});
             helper = Function('helper',{X},symbols.x);
-
+            
             helper_inv = Function('helper_inv',symbols.x,{X});
-
+            
             % helper functions for 'p' if applicable
             if isfield(symbols,'p')
-              P = veccat(symbols.p{:});
-
-              self.Phelper_inv = Function('Phelper_inv',symbols.p,{P});
-
+                P = veccat(symbols.p{:});
+                
+                self.Phelper_inv = Function('Phelper_inv',symbols.p,{P});
+                
             else
-              P = MX.sym('p',0,1);
-            end
-
-            self.np = size(P,1);
-            self.nx = size(X,1);
-
-            if ~isempty(gl_pure)
-                g_helpers = {};
-                for i = 1:length(gl_pure)
-                   g_helpers = {g_helpers{:},MX.sym('g',gl_pure{i}.sparsity()) };
-                end
-                G_helpers = veccat(g_helpers{:});
-
-                self.Ghelper = Function('Ghelper',{G_helpers},g_helpers);
-
-                self.Ghelper_inv = Function('Ghelper_inv',g_helpers,{G_helpers});
-            end
-
-            codegen = false;
-            if isfield(options,'codegen')
-                codegen = options.codegen;
-                options = rmfield(options,'codegen');
-                options.jit = codegen;
+                P = MX.sym('p',0,1);
             end
             
-            quiet = false;
-            if isfield(options,'quiet')
-                quiet = options.quiet;
-                options = rmfield(options,'quiet');
-       		if quiet
-	             options.print_time = false;
-		     options.ipopt.print_level = 0;
-		end
+            self.np = size(P,1);
+            self.nx = size(X,1);
+            
+            if ~isempty(gl_pure)
+                g_helpers = cell(1, length(gl_pure));
+                for k = 1:length(gl_pure)
+                    g_helpers{k} = MX.sym('g',gl_pure{k}.sparsity());
+                end
+                G_helpers = veccat(g_helpers{:});
+                
+                self.Ghelper = Function('Ghelper',{G_helpers},g_helpers);
+                
+                self.Ghelper_inv = Function('Ghelper_inv',g_helpers,{G_helpers});
             end
-
+            
             opt = struct;
-
+            
             gl_pure_v = MX();
             if ~isempty(gl_pure)
-               gl_pure_v = veccat(gl_pure{:});
+                gl_pure_v = veccat(gl_pure{:});
             end
-            if ~isempty(twonorm_objectives)
+            if ~isempty(twonorm_objectives) && ~self.m_fmincon
                 F = [twonorm_objectives{:}];
                 FF = Function('nlp',{X,P},{F});
-
+                
                 JF = FF.jacobian();
                 J_out = JF.call({X,P});
                 J = J_out{1}';
@@ -176,33 +179,86 @@ classdef optisolve < handle
                     Hf = Function('nlp_hess_l',struct('x',X,'p',P,'lam_f',lam_f,'hess_gamma_x_x',triu(lam_f*H+Hs_out{1})),char('x', 'p', 'lam_f', 'lam_g'),char('hess_gamma_x_x'),opt);
                 end
                 if isfield(options,'expand') && options.expand
-                   Hf = Hf.expand();
+                    Hf = Hf.expand();
                 end
-
+                
                 options.hess_lag = Hf;
             end
             self.ng = size(gl_pure_v,1);
-
-            if isfield(options,'callback')
-                mcallback = options.callback;
-                options = rmfield(options,'callback');
-
-                self.callback1 = MyCallback(self, mcallback);
-                options.iteration_callback = self.callback1;
-            end
-
+            
             %opt.starcoloring_threshold = 1000;
-
-            nlp = struct('x',X,'p',P,'f',total_objective,'g',gl_pure_v);
-
-            self.solver = nlpsol('solver',solver, nlp, options);
-
+            
+            if self.m_fmincon
+                % If the solver is fmincon, save the objective function and
+                % constraints.
+                
+                [self.m_fmincon_opt, ~] = self.fmincon_process_options(options);
+                
+                self.m_objfunc = Function('obj', {X, P}, {total_objective}, {'x', 'p'}, {'f'}, opt);
+                self.m_objfunc_g = self.m_objfunc.gradient('x', 'f');
+                
+                % In the following, we must use find() because CasADi does not
+                % support logical indexing (at the moment).
+                if any(gl_equality)
+                    % If there is any equality constraint
+                    self.m_eqc = Function('eqc', {X, P}, {gl_pure_v(find(gl_equality))}, {'x', 'p'}, {'g'}, opt); %#ok<FNDSB>
+                    self.m_eqc_j = self.m_eqc.jacobian('x', 'g');
+                else
+                    self.m_eqc = [];
+                    self.m_eqc_j = [];
+                end
+                
+                if ~all(gl_equality)
+                    % If there is any inequality constraint
+                    self.m_ieqc = Function('ieqc', {X, P}, {gl_pure_v(find(~gl_equality))}, {'x', 'p'}, {'g'}, opt); %#ok<FNDSB>
+                    self.m_ieqc_j = self.m_ieqc.jacobian('x', 'g');
+                else
+                    self.m_ieqc = [];
+                    self.m_ieqc_j = [];
+                end
+                
+            else
+                % Use CasADi's supported solver
+                if isfield(options,'codegen')
+                    codegen = options.codegen;
+                    options = rmfield(options,'codegen');
+                    options.jit = codegen;
+                end
+                
+                if isfield(options,'quiet')
+                    quiet = options.quiet;
+                    options = rmfield(options,'quiet');
+                    if quiet
+                        options.print_time = false;
+                        switch solver
+                            case 'ipopt'
+                                options.ipopt.print_level = 0;
+                            otherwise
+                        end
+                    end
+                end
+                
+                if isfield(options,'callback')
+                    mcallback = options.callback;
+                    options = rmfield(options,'callback');
+                    
+                    self.callback1 = MyCallback(self, mcallback);
+                    options.iteration_callback = self.callback1;
+                end
+                
+                nlp = struct('x',X,'p',P,'f',total_objective,'g',gl_pure_v);
+                
+                self.solver = nlpsol('solver',solver, nlp, options);
+            end
+            
             % Save to class properties
             self.symbols      = symbols;
             self.helper       = helper;
             self.helper_inv   = helper_inv;
             self.gl_equality  = gl_equality;
-
+            
+            % fprintf('optisolve overhead = %g sec;', toc(optisolve_start));
+            
             self.resolve();
         end
 
@@ -221,6 +277,8 @@ classdef optisolve < handle
             % sol.resolve();
             %
             % optival(x) % [-1;-1;0]
+            
+            if self.m_fmincon, self.resolve_fmincon(); return; end
 
             % recall from class properties
             symbols      = self.symbols;
@@ -293,9 +351,157 @@ classdef optisolve < handle
               v = self.symbols.x{i};
               v.setValue(full( helper_outputs{i}));
             end
-
+            
          end
-
+         
     end
+    
+    methods(Access=protected)
+        function [f, g] = fmincon_objfun(self, x)
+            % Objective function for fmincon
+            
+            % Call the saved objective function and its gradient
+            if nargout > 1
+                out = self.m_objfunc_g.call(struct('x', x, 'p', self.m_p0));
+                f = full(out.f);
+                g = full(out.grad);
+            else
+                f = full(self.m_objfunc(x, self.m_p0));
+            end
+        end
+        
+        function [c, ceq, gradc, gradceq] = fmincon_nonlcon(self, x)
+            % Constraint function for fmincon
+            
+            % Call the saved constraint functions and their gradients
+            if nargout > 2
+                inputs = struct('x', x, 'p', self.m_p0);    % inputs to function calls
+            
+                if isempty(self.m_ieqc_j)
+                    c = [];
+                    gradc = [];
+                else
+                    out_c = self.m_ieqc_j.call(inputs);
+                    c = full(out_c.g);
+                    if nargout > 2
+                        gradc = full(out_c.dg_dx).';
+                    end
+                end
+                
+                if isempty(self.m_eqc_j)
+                    ceq = [];
+                    gradceq = [];
+                else
+                    out_ceq = self.m_eqc_j.call(inputs);
+                    ceq = full(out_ceq.g);
+                    if nargout > 2
+                        gradceq = full(out_ceq.dg_dx).';
+                    end
+                end
+            else
+                if isempty(self.m_ieqc)
+                    c = [];
+                else
+                    c = full(self.m_ieqc(x, self.m_p0));
+                end
+                
+                if isempty(self.m_eqc)
+                    ceq = [];
+                else
+                    ceq = full(self.m_eqc(x, self.m_p0));
+                end
+            end
+        end
+        
+        function resolve_fmincon(self)
+            % Solve NLP using fmincon
+            % The functions involved in the optimization must have already
+            % been saved by the constructor (the solver must be set to
+            % 'fmincon' in the constructor).
+            
+            % recall from class properties
+            symbols      = self.symbols;
+            helper       = self.helper;
+            helper_inv   = self.helper_inv;
+            gl_equality  = self.gl_equality;
+            
+            solver_inputs = struct;
 
+            helper_inv_inputs = cell(1,helper_inv.n_in);
+            % compose lbx
+            for i=1:length(symbols.x)
+                helper_inv_inputs{i} = symbols.x{i}.lb;
+            end
+            
+            out = helper_inv.call(helper_inv_inputs);
+            solver_inputs.lbx = full(out{1});
+            
+            helper_inv_inputs = cell(1,helper_inv.n_in);
+            % compose x0
+            for i=1:length(symbols.x)
+                helper_inv_inputs{i} = symbols.x{i}.init;
+            end
+            
+            out = helper_inv.call(helper_inv_inputs);
+            solver_inputs.x0 = full(out{1});
+            
+            helper_inv_inputs = cell(1,helper_inv.n_in);
+            % compose ubx
+            for i=1:length(symbols.x)
+                helper_inv_inputs{i} = symbols.x{i}.ub;
+            end
+            
+            out = helper_inv.call(helper_inv_inputs);
+            solver_inputs.ubx = full(out{1});
+            
+            if isfield(symbols,'p')
+                Phelper_inv_inputs = cell(1,self.Phelper_inv.n_in);
+                
+                % compose p0
+                for i=1:length(symbols.p)
+                    Phelper_inv_inputs{i} = symbols.p{i}.value;
+                end
+                out = self.Phelper_inv.call(Phelper_inv_inputs);
+                self.m_p0 = out{1};
+            end
+            
+            % disp(self.m_fmincon_opt);
+            
+            % Call fmincon()
+            solver_outputs = struct();
+            [solver_outputs.x] = fmincon(@self.fmincon_objfun, solver_inputs.x0,...
+                [], [], [], [], ...
+                solver_inputs.lbx, solver_inputs.ubx, ...
+                @self.fmincon_nonlcon, ...
+                self.m_fmincon_opt);
+            
+            self.readoutputs(solver_outputs);
+            
+        end
+    end
+    
+    methods(Static, Hidden=true)
+        function [opt, options] = fmincon_process_options(options)
+            % Process the options for fmincon(), returns remaining unused
+            % options.
+            if isfield(options, 'fmincon')
+                % Save the options for fmincon
+                opt = options.fmincon;
+                options = rmfield(options, 'fmincon');
+            else
+                opt = optimoptions('fmincon');
+            end
+            
+            if isfield(options,'quiet')
+                quiet = options.quiet;
+                options = rmfield(options,'quiet');
+                if quiet
+                    opt = optimoptions(opt, 'Display', 'off');
+                end
+            end
+            
+            % Set the options for gradient computations
+            opt = optimoptions(opt, 'GradObj', 'on', 'GradConstr', 'on');
+        end
+    end
 end

--- a/src/optisolve.m
+++ b/src/optisolve.m
@@ -48,6 +48,8 @@ classdef optisolve < handle
         m_fmincon_opt   % Options for fmincon()
         
         m_fmincon = false;  % If fmincon is used
+        
+        fmincon_flag = NaN; % exit flag of fmincon, after it has solved the problem
     end
 
     methods
@@ -469,7 +471,7 @@ classdef optisolve < handle
             
             % Call fmincon()
             solver_outputs = struct();
-            [solver_outputs.x] = fmincon(@self.fmincon_objfun, solver_inputs.x0,...
+            [solver_outputs.x, ~, self.fmincon_flag] = fmincon(@self.fmincon_objfun, solver_inputs.x0,...
                 [], [], [], [], ...
                 solver_inputs.lbx, solver_inputs.ubx, ...
                 @self.fmincon_nonlcon, ...

--- a/src/optivar.m
+++ b/src/optivar.m
@@ -50,22 +50,27 @@ classdef optivar < OptimizationObject
             %  x = optivar(n)                  Column vector of length n
             %  x = optivar(n,m)                Matrix of shape n-by-m
             %  x = optivar(n,m,name)           Supply a name for printing
-           if isempty(varargin)
+            %  x = optivar(obj)                Wrap an existing MX object
+           if nargin == 0
                shape = 1;
-           elseif length(varargin)==1
+           elseif nargin == 1
                shape = varargin{1};
-           elseif length(varargin)>1
+           elseif nargin > 1
                shape = [varargin{1};varargin{2}];
            end
            
-           if length(varargin)==3
-               name = varargin{3};
+           if nargin == 3
+               name = varargin(3);
            else
-               name = 'x';
+               if isnumeric(shape)
+                   name = {'x'};    % automatic name
+               else
+                   name = {};       % wrapping an MX object
+               end
            end
            
            import casadi.*
-           self@OptimizationObject(shape,name);
+           self@OptimizationObject(shape,name{:});
            self.lb = -inf*DM.ones(self.sparsity());
            self.ub = inf*DM.ones(self.sparsity());
            self.init = DM.zeros(self.sparsity());

--- a/src/optivar.m
+++ b/src/optivar.m
@@ -5,6 +5,7 @@ classdef optivar < OptimizationObject
     %  x = optivar(n)                  Column vector of length n
     %  x = optivar(n,m)                Matrix of shape n-by-m
     %  x = optivar(n,m,name)           Supply a name for printing
+    %  x = optivar(MX mx)              Wrap an existing MX object
     %
     %  optivar Methods:
     %    optivar  - constructor

--- a/src/sort_constraints.m
+++ b/src/sort_constraints.m
@@ -13,22 +13,22 @@ function [ gl_pure, gl_equality] = sort_constraints( gl )
     % For each entry in `gl_pure`, this list contains a boolean.
 
     gl_pure = {};
-    gl_equality = [];
+    gl_equality = false(1,0);
     for g = gl
-        g = g{1};
-        if g.is_op(casadi.OP_LE) || g.is_op(casadi.OP_LT)
+        h = g{1};
+        if h.is_op(casadi.OP_LE) || h.is_op(casadi.OP_LT)
             args = {};
-            while g.is_op(casadi.OP_LE) || g.is_op(casadi.OP_LT)
-               args = {args{:} g.dep(1)};
-               g = g.dep(0);
+            while h.is_op(casadi.OP_LE) || h.is_op(casadi.OP_LT)
+               args = [args {h.dep(1)}]; %#ok<*AGROW>
+               h = h.dep(0);
             end
-            args = {args{:} g};
+            args = [args {h}];
             for i=1:length(args)-1
-                gl_pure = {gl_pure{:},args{i+1} - args{i}};
+                gl_pure = [gl_pure, {args{i+1} - args{i}}];
                 gl_equality = [gl_equality, false];
             end
-        elseif g.is_op(casadi.OP_EQ)
-        	gl_pure = {gl_pure{:},g.dep(0) - g.dep(1)};
+        elseif h.is_op(casadi.OP_EQ)
+        	gl_pure = [gl_pure, {h.dep(0) - h.dep(1)}];
             gl_equality = [gl_equality, true];
         else
             error('Constraint type unkown. Use ==, >= or <= .');


### PR DESCRIPTION
The constructors of various optistack classes are changed so that they can take an existing MX symbolic object and wrap it in the optistack object. This is useful in cases when one wants to reuse existing code that creates casadi objects and expressions / constraints.
